### PR TITLE
feat: run post_installation plugins tasks

### DIFF
--- a/adm/_plugins.postinstall
+++ b/adm/_plugins.postinstall
@@ -36,5 +36,5 @@ fi
 
 if test -x "${PLUGIN_HOME}/postinstall"; then
     echo "Running post-installation plugin tasks"
-    plugin_wrapper ${NAME} ${PLUGIN_HOME}/postinstall
+    plugin_wrapper "${NAME}" "${PLUGIN_HOME}/postinstall"
 fi

--- a/adm/_plugins.postinstall
+++ b/adm/_plugins.postinstall
@@ -33,3 +33,8 @@ if ! test -L "${PLUGIN_HOME}"; then
     rm -Rf "${PLUGIN_HOME}/python2_virtualenv_sources"
     rm -Rf "${PLUGIN_HOME}/node_sources"
 fi
+
+if test -x "${PLUGIN_HOME}/postinstall"; then
+    echo "Running post-installation plugin tasks"
+    plugin_wrapper ${NAME} ${PLUGIN_HOME}/postinstall
+fi


### PR DESCRIPTION
Tasks are in an executable file named 'postinstall' located at the root of the plugin.